### PR TITLE
Bug fix for COM ports higher than COM9 under Windows

### DIFF
--- a/serialport-win32.cpp
+++ b/serialport-win32.cpp
@@ -54,7 +54,8 @@ bool StandardSerialPortBackend::open()
     }
 //    qDebug() << "!d" << tr("DBG -- Serial Port Open...");
 
-    QString name = respeqtSettings->serialPortName();
+    QString name("\\\\.\\");
+    name.append(respeqtSettings->serialPortName());
 
     mHandle = (CreateFile(
         (WCHAR*)name.utf16(),


### PR DESCRIPTION
Hi Joey,
I'm impressed about git tooling. It works like a charm.
Before I start with bluetooth related updates, I wanted to try with a very small update (to test the git development workflow).
I created a pull request, so you can integrate a small bug fix to support serial ports with a higher number than COM9 (that means COM10, COM11, etc.) under Windows.
Best Regards
Marcin
