### PR TITLE
timeout for the format command changed from $03 to $E0

### DIFF
--- a/diskimage.cpp
+++ b/diskimage.cpp
@@ -1128,7 +1128,7 @@ void SimpleDiskImage::getStatus(QByteArray &status)
                 (m_newGeometry.bytesPerSector() == 256) * 32 |
                 (m_newGeometry.bytesPerSector() == 128 && m_newGeometry.sectorsPerTrack() == 26) * 128;
     status[1] = 0xFF;
-    status[2] = 3;
+    status[2] = 0xE0; // Timeout for format ($E0) - Time the drive will need to format a disk (1050 returns 0xe0, XF551 0xfe)
     status[3] = 0;
 }
 


### PR DESCRIPTION
Hi Joey,
one more update (before BT stuff comes):
The GetStatus command retuns a timeout value for disk formatting.
The old value (3 ~sec) was good enough for emulated drives, but not for real drives.
The use case is: 
Atari gets status from the emulated drive D1 and uses the timeout value (from RespeQt) while formatting a real drive D2. See below discussion:

http://atariage.com/forums/topic/232649-sio-format-command-question/

I don't know why Ray has not released the bug fix in the AspeQt...

Regards
Marcin
