### PR TITLE
Software Handshaking / Bluetooth Support

### DIFF
--- a/optionsdialog.cpp
+++ b/optionsdialog.cpp
@@ -40,6 +40,7 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
     /* Retrieve application settings */
     m_ui->serialPortDeviceNameEdit->setText(respeqtSettings->serialPortName());
     m_ui->serialPortHandshakeCombo->setCurrentIndex(respeqtSettings->serialPortHandshakingMethod());
+    m_ui->serialPortWriteDelayCombo->setCurrentIndex(respeqtSettings->serialPortWriteDelay());
     m_ui->serialPortBaudCombo->setCurrentIndex(respeqtSettings->serialPortMaximumSpeed());
     m_ui->serialPortUseDivisorsBox->setChecked(respeqtSettings->serialPortUsePokeyDivisors());
     m_ui->serialPortDivisorEdit->setValue(respeqtSettings->serialPortPokeyDivisor());
@@ -90,6 +91,8 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
         m_ui->i18nLanguageCombo->setCurrentIndex(i+2);
 	}
     }
+    m_ui->serialPortWriteDelayLabel->setVisible(respeqtSettings->serialPortHandshakingMethod()==3);
+    m_ui->serialPortWriteDelayCombo->setVisible(respeqtSettings->serialPortHandshakingMethod()==3);
 }
 
 OptionsDialog::~OptionsDialog()
@@ -113,6 +116,7 @@ void OptionsDialog::OptionsDialog_accepted()
 {
     respeqtSettings->setSerialPortName(m_ui->serialPortDeviceNameEdit->text());
     respeqtSettings->setSerialPortHandshakingMethod(m_ui->serialPortHandshakeCombo->currentIndex());
+    respeqtSettings->setSerialPortWriteDelay(m_ui->serialPortWriteDelayCombo->currentIndex());
     respeqtSettings->setSerialPortMaximumSpeed(m_ui->serialPortBaudCombo->currentIndex());
     respeqtSettings->setSerialPortUsePokeyDivisors(m_ui->serialPortUseDivisorsBox->isChecked());
     respeqtSettings->setSerialPortPokeyDivisor(m_ui->serialPortDivisorEdit->value());
@@ -166,6 +170,12 @@ void OptionsDialog::on_treeWidget_itemClicked(QTreeWidgetItem* item, int /*colum
     }
     m_ui->serialPortBox->setCheckState(itemStandard->checkState(0));
     m_ui->atariSioBox->setCheckState(itemAtariSio->checkState(0));
+}
+
+void OptionsDialog::on_serialPortHandshakeCombo_currentIndexChanged(int index)
+{
+    m_ui->serialPortWriteDelayLabel->setVisible(index==3);
+    m_ui->serialPortWriteDelayCombo->setVisible(index==3);
 }
 
 void OptionsDialog::on_serialPortUseDivisorsBox_toggled(bool checked)

--- a/optionsdialog.h
+++ b/optionsdialog.h
@@ -34,6 +34,7 @@ private:
     QTreeWidgetItem *itemStandard, *itemAtariSio, *itemEmulation, *itemI18n;
 
 private slots:
+    void on_serialPortHandshakeCombo_currentIndexChanged(int index);
     void on_useEmulationCustomCasBaudBox_toggled(bool checked);
     void on_serialPortUseDivisorsBox_toggled(bool checked);
     void on_treeWidget_itemClicked(QTreeWidgetItem* item, int column);

--- a/optionsdialog.ui
+++ b/optionsdialog.ui
@@ -195,7 +195,68 @@
           </item>
           <item>
            <property name="text">
-            <string>NONE (Windows ONLY - Experimental)</string>
+            <string>SOFTWARE</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="serialPortWriteDelayLabel">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Write delay [ms]:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="serialPortWriteDelayCombo">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="currentIndex">
+           <number>1</number>
+          </property>
+          <item>
+           <property name="text">
+            <string>0</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>10</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>20</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>30</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>40</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>50</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>60</string>
            </property>
           </item>
          </widget>

--- a/respeqtsettings.cpp
+++ b/respeqtsettings.cpp
@@ -34,6 +34,7 @@ RespeqtSettings::RespeqtSettings()
     /* Standard serial port backend */
     mSerialPortName = mSettings->value("SerialPortName", StandardSerialPortBackend::defaultPortName()).toString();
     mSerialPortHandshakingMethod = mSettings->value("HandshakingMethod", 0).toInt();
+    mSerialPortWriteDelay = mSettings->value("WriteDelay", 1).toInt();
     mSerialPortMaximumSpeed = mSettings->value("MaximumSerialPortSpeed", 2).toInt();
     mSerialPortUsePokeyDivisors = mSettings->value("SerialPortUsePokeyDivisors", false).toBool();
     mSerialPortPokeyDivisor = mSettings->value("SerialPortPokeyDivisor", 6).toInt();
@@ -113,6 +114,7 @@ void RespeqtSettings::saveSessionToFile(const QString &fileName)
         s.setValue("AtariSioHandshakingMethod", mAtariSioHandshakingMethod);
         s.setValue("SerialPortName", mSerialPortName);
         s.setValue("HandshakingMethod", mSerialPortHandshakingMethod);
+        s.setValue("WriteDelay", mSerialPortWriteDelay);
         s.setValue("MaximumSerialPortSpeed", mSerialPortMaximumSpeed);
         s.setValue("SerialPortUsePokeyDivisors", mSerialPortUsePokeyDivisors);
         s.setValue("SerialPortPokeyDivisor", mSerialPortPokeyDivisor);
@@ -161,6 +163,7 @@ void RespeqtSettings::saveSessionToFile(const QString &fileName)
         mAtariSioHandshakingMethod = s.value("AtariSioHandshakingMethod", 0).toInt();
         mSerialPortName = s.value("SerialPortName", StandardSerialPortBackend::defaultPortName()).toString();
         mSerialPortHandshakingMethod = s.value("HandshakingMethod", 0).toInt();
+        mSerialPortWriteDelay = s.value("WriteDelay", 1).toInt();
         mSerialPortMaximumSpeed = s.value("MaximumSerialPortSpeed", 2).toInt();
         mSerialPortUsePokeyDivisors = s.value("SerialPortUsePokeyDivisors", false).toBool();
         mSerialPortPokeyDivisor = s.value("SerialPortPokeyDivisor", 6).toInt();
@@ -282,6 +285,17 @@ void RespeqtSettings::setSerialPortHandshakingMethod(int method)
 { 
     mSerialPortHandshakingMethod = method;
     if(mSessionFileName == "") mSettings->setValue("HandshakingMethod", mSerialPortHandshakingMethod);
+}
+
+int RespeqtSettings::serialPortWriteDelay()
+{
+    return mSerialPortWriteDelay;
+}
+
+void RespeqtSettings::setSerialPortWriteDelay(int delay)
+{
+    mSerialPortWriteDelay = delay;
+    if(mSessionFileName == "") mSettings->setValue("WriteDelay", mSerialPortWriteDelay);
 }
 
 int RespeqtSettings::backend()

--- a/respeqtsettings.h
+++ b/respeqtsettings.h
@@ -51,6 +51,9 @@ public:
     int atariSioHandshakingMethod();
     void setAtariSioHandshakingMethod(int method);
 
+    int serialPortWriteDelay();
+    void setSerialPortWriteDelay(int delay);
+
     int backend();
     void setBackend(int backend);
 
@@ -199,6 +202,7 @@ private:
 //
     QString mSerialPortName;
     int mSerialPortHandshakingMethod;
+    int mSerialPortWriteDelay;
     int mSerialPortMaximumSpeed;
     bool mSerialPortUsePokeyDivisors;
     int mSerialPortPokeyDivisor;

--- a/serialport-unix.h
+++ b/serialport-unix.h
@@ -37,12 +37,15 @@ public:
     bool writeError();
     bool setSpeed(int speed);
     bool writeRawFrame(const QByteArray &data);
+    void setActiveSioDevices(const QByteArray &data);
 
 private:
     bool mCanceled;
     int mHandle;
     int mSpeed;
     int mMethod;
+    int mDelay;
+    QByteArray mSioDevices;
 
     bool setNormalSpeed();
     bool setHighSpeed();
@@ -79,6 +82,7 @@ public:
     bool writeError();
     bool setSpeed(int speed);
     bool writeRawFrame(const QByteArray &data);
+    void setActiveSioDevices(const QByteArray &data);
 
 private:
     int mHandle, mCancelHandles[2];

--- a/serialport-win32.cpp
+++ b/serialport-win32.cpp
@@ -67,15 +67,15 @@ bool StandardSerialPortBackend::open()
         0
     ));
     if (mHandle == INVALID_HANDLE_VALUE) {
-        qCritical() << "!e" << tr("Cannot open serial port '%1': %2").arg(name, lastErrorMessage());
+        qCritical() << "!e" << tr("Cannot open serial port '%1': %2").arg(respeqtSettings->serialPortName(), lastErrorMessage());
         return false;
     }
     if (!EscapeCommFunction(mHandle, CLRRTS)) {
-        qCritical() << "!e" << tr("Cannot clear RTS line in serial port '%1': %2").arg(name, lastErrorMessage());
+        qCritical() << "!e" << tr("Cannot clear RTS line in serial port '%1': %2").arg(respeqtSettings->serialPortName(), lastErrorMessage());
         return false;
     }
     if (!EscapeCommFunction(mHandle, CLRDTR)) {
-        qCritical() << "!e" << tr("Cannot clear DTR line in serial port '%1': %2").arg(name, lastErrorMessage());
+        qCritical() << "!e" << tr("Cannot clear DTR line in serial port '%1': %2").arg(respeqtSettings->serialPortName(), lastErrorMessage());
         return false;
     }
 

--- a/serialport-win32.h
+++ b/serialport-win32.h
@@ -37,6 +37,7 @@ public:
     bool writeError();
     bool setSpeed(int speed);
     bool writeRawFrame(const QByteArray &data);
+    void setActiveSioDevices(const QByteArray &data);
 
 private:
     bool mCanceled;
@@ -44,6 +45,8 @@ private:
     void *mHandle, *mCancelHandle;
     int mSpeed;
     int mMethod;
+    int mDelay;
+    QByteArray mSioDevices;
 
     bool setNormalSpeed();
     bool setHighSpeed();
@@ -80,6 +83,7 @@ public:
     bool writeError();
     bool setSpeed(int speed);
     bool writeRawFrame(const QByteArray &data);
+    void setActiveSioDevices(const QByteArray &data);
 };
 
 #endif // SERIALPORTWIN32_H

--- a/serialport.h
+++ b/serialport.h
@@ -12,6 +12,9 @@
 #include <QObject>
 #include <QByteArray>
 
+#define SOFTWARE_HANDSHAKE 3
+#define SLEEP_FACTOR 10000
+
 class AbstractSerialPortBackend : public QObject
 {
     Q_OBJECT
@@ -56,6 +59,7 @@ public:
     virtual bool writeError() = 0;
     virtual bool setSpeed(int speed) = 0;
     virtual bool writeRawFrame(const QByteArray &data) = 0;
+    virtual void setActiveSioDevices(const QByteArray &data) = 0;
 signals:
     void statusChanged(QString status);
 };

--- a/sioworker.cpp
+++ b/sioworker.cpp
@@ -86,6 +86,16 @@ void SioWorker::start(Priority p)
             break;
     }
 
+    QByteArray data;
+    for (int i=0; i <= 255; i++)
+    {
+        if(devices[i])
+        {
+            data.append(i);
+        }
+    }
+    mPort->setActiveSioDevices(data);
+
     mustTerminate = false;
     QThread::start(p);
 }
@@ -150,6 +160,18 @@ void SioWorker::installDevice(quint8 no, SioDevice *device)
     devices[no] = device;
     device->setDeviceNo(no);
     deviceMutex->unlock();
+    if(mPort)
+    {
+        QByteArray data;
+        for (int i=0; i <= 255; i++)
+        {
+            if(devices[i])
+            {
+                data.append(i);
+            }
+        }
+        mPort->setActiveSioDevices(data);
+    }
 }
 
 void SioWorker::uninstallDevice(quint8 no)
@@ -160,6 +182,18 @@ void SioWorker::uninstallDevice(quint8 no)
     }
     devices[no] = 0;
     deviceMutex->unlock();
+    if(mPort)
+    {
+        QByteArray data;
+        for (int i=0; i <= 255; i++)
+        {
+            if(devices[i])
+            {
+                data.append(i);
+            }
+        }
+        mPort->setActiveSioDevices(data);
+    }
 }
 
 void SioWorker::swapDevices(quint8 d1, quint8 d2)


### PR DESCRIPTION
Hi Joey,
here is the big update.
Under Tools / Options you can select now Handshake Method: SOFTWARE (supported for Windows, Linux and hopefully for MAC, too).
This means Command Frame detection in Software (analyzing data content instead of relying on CTS/RI/DSR). 
There is also additional delay needed to support BT communication.
Under Tools / Options you can select the delay from 0ms to 60 ms.
0ms (no additional delay) is usefull with cheap USB2Seial(TTL) cables with only Rxd/Txd lines, otherwise 10ms delay is recommended for BT.
If you select CTS / RI / DSR as a Handshake Method, RespeQt works like it worked before.
My changes are only acitve for Handshake Method: SOFTWARE
Regards
Marcin
P.S.
In the SIO2BT manual there is a chapter about Buetooth communication with AspeQt/RespeQt under Windows / Linux:
https://drive.google.com/file/d/0B3-191R-U_S1blpUTFBsRW1iRUE
