### PR TITLE
Fix for issue #21, Performance issue with Software handshaking, using…

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1230,7 +1230,11 @@ void MainWindow::bootExe(const QString &fileName)
     SioDevice *old = sio->getDevice(0x31);
     AutoBoot loader(sio, old);    
     AutoBootDialog dlg(this);
-    if (!loader.open(fileName, respeqtSettings->useHighSpeedExeLoader())) {
+
+    bool highSpeed =    respeqtSettings->useHighSpeedExeLoader() &&
+                        (respeqtSettings->serialPortHandshakingMethod() != HANDSHAKE_SOFTWARE);
+
+    if (!loader.open(fileName, highSpeed)) {
         return;
     }
 

--- a/optionsdialog.cpp
+++ b/optionsdialog.cpp
@@ -91,8 +91,15 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
         m_ui->i18nLanguageCombo->setCurrentIndex(i+2);
 	}
     }
-    m_ui->serialPortWriteDelayLabel->setVisible(respeqtSettings->serialPortHandshakingMethod()==3);
-    m_ui->serialPortWriteDelayCombo->setVisible(respeqtSettings->serialPortHandshakingMethod()==3);
+    bool software_handshake = (respeqtSettings->serialPortHandshakingMethod()==HANDSHAKE_SOFTWARE);
+    m_ui->serialPortWriteDelayLabel->setVisible(software_handshake);
+    m_ui->serialPortWriteDelayCombo->setVisible(software_handshake);
+    m_ui->serialPortBaudLabel->setVisible(!software_handshake);
+    m_ui->serialPortBaudCombo->setVisible(!software_handshake);
+    m_ui->serialPortUseDivisorsBox->setVisible(!software_handshake);
+    m_ui->serialPortDivisorLabel->setVisible(!software_handshake);
+    m_ui->serialPortDivisorEdit->setVisible(!software_handshake);
+    m_ui->emulationHighSpeedExeLoaderBox->setVisible(!software_handshake);
 }
 
 OptionsDialog::~OptionsDialog()
@@ -174,8 +181,15 @@ void OptionsDialog::on_treeWidget_itemClicked(QTreeWidgetItem* item, int /*colum
 
 void OptionsDialog::on_serialPortHandshakeCombo_currentIndexChanged(int index)
 {
-    m_ui->serialPortWriteDelayLabel->setVisible(index==3);
-    m_ui->serialPortWriteDelayCombo->setVisible(index==3);
+    bool software_handshake = (index==HANDSHAKE_SOFTWARE);
+    m_ui->serialPortWriteDelayLabel->setVisible(software_handshake);
+    m_ui->serialPortWriteDelayCombo->setVisible(software_handshake);
+    m_ui->serialPortBaudLabel->setVisible(!software_handshake);
+    m_ui->serialPortBaudCombo->setVisible(!software_handshake);
+    m_ui->serialPortUseDivisorsBox->setVisible(!software_handshake);
+    m_ui->serialPortDivisorLabel->setVisible(!software_handshake);
+    m_ui->serialPortDivisorEdit->setVisible(!software_handshake);
+    m_ui->emulationHighSpeedExeLoaderBox->setVisible(!software_handshake);
 }
 
 void OptionsDialog::on_serialPortUseDivisorsBox_toggled(bool checked)

--- a/optionsdialog.ui
+++ b/optionsdialog.ui
@@ -195,7 +195,12 @@
           </item>
           <item>
            <property name="text">
-            <string>SOFTWARE</string>
+            <string>NONE</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>SOFTWARE (SIO2BT)</string>
            </property>
           </item>
          </widget>

--- a/serialport.h
+++ b/serialport.h
@@ -12,7 +12,15 @@
 #include <QObject>
 #include <QByteArray>
 
-#define SOFTWARE_HANDSHAKE 3
+enum eHandshake
+{
+    HANDSHAKE_RI=0,
+    HANDSHAKE_DSR=1,
+    HANDSHAKE_CTS=2,
+    HANDSHAKE_NO_HANDSHAKE=3,
+    HANDSHAKE_SOFTWARE=4
+};
+
 #define SLEEP_FACTOR 10000
 
 class AbstractSerialPortBackend : public QObject


### PR DESCRIPTION
… wired SIO2PC

Hi Joey,
atari8warez created an issue #21 for the Software Handshaking feature.
He was right, because this approach for handling SIO communication works only for 19200.

I commited my changes, in particular:
- renamed "Software" Handshake to "SOFTWARE (SIO2BT)" Handshake
- disabled high speed for "SOFTWARE (SIO2BT)" Handshake
- added atari8warez' "NONE" Handshake (for Windows) back to RespeQt (with HI-SPEED support)
- implemented Linux/Mac version of the "NONE" Handshake (with HI-SPEED support)
- added correction to all non hardware handshaking methods - 0,5ms sleep after the command frame is read (hardware handshaking methods were waiting here for the command line to go off). Without that, the ACK byte could arrive at ATARI to early (and would be lost).

I will try to find out more details regarding the MAC timing (with a login analyzer) and possibly commit some changes (for MAC only). 
The next feature I would like to take a look at is the PCLINK.
Best Regards
Marcin
