### PR TITLE
re-introduced clear input buffer for software handshake (SIO2BT)

### DIFF
--- a/serialport-unix.cpp
+++ b/serialport-unix.cpp
@@ -342,6 +342,12 @@ QByteArray StandardSerialPortBackend::readCommandFrame()
 
     if(mMethod==HANDSHAKE_SOFTWARE)
     {
+        if (tcflush(mHandle, TCIFLUSH) != 0)
+        {
+            qCritical() << "!e" << tr("Cannot clear serial port read buffer: %1").arg(lastErrorMessage());
+            return data;
+        }
+
         const int size = 4;
         quint8 expected = 0;
         quint8 got = 1;

--- a/serialport-win32.cpp
+++ b/serialport-win32.cpp
@@ -309,6 +309,11 @@ QByteArray StandardSerialPortBackend::readCommandFrame()
 
     if(mMethod==HANDSHAKE_SOFTWARE)
     {
+        if (!PurgeComm(mHandle, PURGE_RXCLEAR)) {
+            qCritical() << "!e" << tr("Cannot clear serial port read buffer: %1").arg(lastErrorMessage());
+            return data;
+        }
+
         const int size = 4;
         quint8 expected = 0;
         quint8 got = 1;


### PR DESCRIPTION
on entering command frame detection.
I have removed it in one of my last commits, but then I realized that this makes sense in error cases.
For example, the ATARI sends (without a SIO patch) a bunch of Command Frames.
Without clearing the buffer, all these (identical) command frames would be queued and processed, which is not the intended behaviour.
