### PR TITLE
revert last changes

### DIFF
--- a/optionsdialog.cpp
+++ b/optionsdialog.cpp
@@ -96,8 +96,8 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
     bool software_handshake = (respeqtSettings->serialPortHandshakingMethod()==HANDSHAKE_SOFTWARE);
     m_ui->serialPortWriteDelayLabel->setVisible(software_handshake);
     m_ui->serialPortWriteDelayCombo->setVisible(software_handshake);
-    m_ui->serialPortBaudLabel->setEnabled(software_handshake || !m_ui->serialPortUseDivisorsBox->isChecked());
-    m_ui->serialPortBaudCombo->setEnabled(software_handshake || !m_ui->serialPortUseDivisorsBox->isChecked());
+    m_ui->serialPortBaudLabel->setVisible(!software_handshake);
+    m_ui->serialPortBaudCombo->setVisible(!software_handshake);
     m_ui->serialPortUseDivisorsBox->setVisible(!software_handshake);
     m_ui->serialPortDivisorLabel->setVisible(!software_handshake);
     m_ui->serialPortDivisorEdit->setVisible(!software_handshake);
@@ -189,8 +189,8 @@ void OptionsDialog::on_serialPortHandshakeCombo_currentIndexChanged(int index)
     bool software_handshake = (index==HANDSHAKE_SOFTWARE);
     m_ui->serialPortWriteDelayLabel->setVisible(software_handshake);
     m_ui->serialPortWriteDelayCombo->setVisible(software_handshake);
-    m_ui->serialPortBaudLabel->setEnabled(software_handshake || !m_ui->serialPortUseDivisorsBox->isChecked());
-    m_ui->serialPortBaudCombo->setEnabled(software_handshake || !m_ui->serialPortUseDivisorsBox->isChecked());
+    m_ui->serialPortBaudLabel->setVisible(!software_handshake);
+    m_ui->serialPortBaudCombo->setVisible(!software_handshake);
     m_ui->serialPortUseDivisorsBox->setVisible(!software_handshake);
     m_ui->serialPortDivisorLabel->setVisible(!software_handshake);
     m_ui->serialPortDivisorEdit->setVisible(!software_handshake);

--- a/serialport-unix.cpp
+++ b/serialport-unix.cpp
@@ -91,14 +91,7 @@ bool StandardSerialPortBackend::open()
         return false;
     }
 
-    if(mMethod==HANDSHAKE_SOFTWARE)
-    {
-        if (!setHighSpeed()) {
-            close();
-            return false;
-        }
-    }
-    else
+    if(mMethod!=HANDSHAKE_SOFTWARE)
     {
         int status;
         if (ioctl(mHandle, TIOCMGET, &status) < 0) {
@@ -110,14 +103,14 @@ bool StandardSerialPortBackend::open()
             qCritical() << "!e" << tr("Cannot clear DTR and RTS lines in serial port '%1': %2").arg(name, lastErrorMessage());
             return false;
         }
-
-        if (!setNormalSpeed()) {
-            close();
-            return false;
-        }
     }
 
     mCanceled = false;
+
+    if (!setNormalSpeed()) {
+        close();
+        return false;
+    }
 
     QString m;
     switch (mMethod) {
@@ -168,13 +161,11 @@ void StandardSerialPortBackend::cancel()
 
 int StandardSerialPortBackend::speedByte()
 {
-    if (    (respeqtSettings->serialPortHandshakingMethod()!=HANDSHAKE_SOFTWARE) &&
-            (respeqtSettings->serialPortUsePokeyDivisors()))
-    {
+    if (respeqtSettings->serialPortHandshakingMethod()==HANDSHAKE_SOFTWARE) {
+        return 0x28; // standard speed (19200)
+    } else if (respeqtSettings->serialPortUsePokeyDivisors()) {
         return respeqtSettings->serialPortPokeyDivisor();
-    }
-    else
-    {
+    } else {
         int speed = 0x08;
         switch (respeqtSettings->serialPortMaximumSpeed()) {
         case 0:
@@ -200,14 +191,9 @@ bool StandardSerialPortBackend::setNormalSpeed()
 bool StandardSerialPortBackend::setHighSpeed()
 {
     mHighSpeed = true;
-
-    if (    (respeqtSettings->serialPortHandshakingMethod()!=HANDSHAKE_SOFTWARE) &&
-            (respeqtSettings->serialPortUsePokeyDivisors()))
-    {
+    if (respeqtSettings->serialPortUsePokeyDivisors()) {
         return setSpeed(divisorToBaud(respeqtSettings->serialPortPokeyDivisor()));
-    }
-    else
-    {
+    } else {
         int speed = 57600;
         switch (respeqtSettings->serialPortMaximumSpeed()) {
         case 0:

--- a/serialport-win32.cpp
+++ b/serialport-win32.cpp
@@ -77,11 +77,6 @@ bool StandardSerialPortBackend::open()
             qCritical() << "!e" << tr("Cannot open serial port '%1': %2").arg(respeqtSettings->serialPortName(), lastErrorMessage());
             return false;
         }
-
-        if (!setHighSpeed()) {
-            close();
-            return false;
-        }
     }
     else
     {
@@ -106,17 +101,16 @@ bool StandardSerialPortBackend::open()
             qCritical() << "!e" << tr("Cannot clear DTR line in serial port '%1': %2").arg(respeqtSettings->serialPortName(), lastErrorMessage());
             return false;
         }
-
-        if (!setNormalSpeed()) {
-            close();
-            return false;
-        }
     }
 
     mCanceled = false;
 
     mCancelHandle = CreateEvent(0, true, false, 0);
 
+    if (!setNormalSpeed()) {
+        close();
+        return false;
+    }
 
     QString m;
     switch (mMethod) {
@@ -172,13 +166,12 @@ void StandardSerialPortBackend::cancel()
 int StandardSerialPortBackend::speedByte()
 {
 //    qDebug() << "!d" << tr("DBG -- Serial Port speedByte...");
-    if (    (respeqtSettings->serialPortHandshakingMethod()!=HANDSHAKE_SOFTWARE) &&
-            (respeqtSettings->serialPortUsePokeyDivisors()))
-    {
+
+    if (respeqtSettings->serialPortHandshakingMethod()==HANDSHAKE_SOFTWARE) {
+        return 0x28; // standard speed (19200)
+    } else if (respeqtSettings->serialPortUsePokeyDivisors()) {
         return respeqtSettings->serialPortPokeyDivisor();
-    }
-    else
-    {
+    } else {
         int speed = 0x08;
         switch (respeqtSettings->serialPortMaximumSpeed()) {
         case 0:
@@ -204,13 +197,9 @@ bool StandardSerialPortBackend::setNormalSpeed()
 bool StandardSerialPortBackend::setHighSpeed()
 {
     mHighSpeed = true;
-    if (    (respeqtSettings->serialPortHandshakingMethod()!=HANDSHAKE_SOFTWARE) &&
-            (respeqtSettings->serialPortUsePokeyDivisors()))
-    {
+    if (respeqtSettings->serialPortUsePokeyDivisors()) {
         return setSpeed(divisorToBaud(respeqtSettings->serialPortPokeyDivisor()));
-    }
-    else
-    {
+    } else {
         int speed = 57600;
         switch (respeqtSettings->serialPortMaximumSpeed()) {
         case 0:


### PR DESCRIPTION
Revert changes, because baudrate settings are not relevant to a virtual serial port driver

Today HIAS asked me to check if the virtual serial port driver is affected by the baudrate settings.
I realized that this is not the case for a Bluetooth connection.
So I would like to revert my changes.
