### PR TITLE
Fix crash from double call to closeEvent

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -561,8 +561,10 @@ void MainWindow::closeEvent(QCloseEvent *event)
     }
 
     delete textPrinterWindow;
+    textPrinterWindow = NULL;
     //
     delete docDisplayWindow;
+    docDisplayWindow = NULL;
 
     for (int i = DISK_BASE_CDEVIC; i < (DISK_BASE_CDEVIC+DISK_COUNT); i++) {
         SimpleDiskImage *s = qobject_cast <SimpleDiskImage*> (sio->getDevice(i));


### PR DESCRIPTION
At least on OSX, closeEvent gets called two times. This leads to invalid access crash on application exit.
This happens, because the pointer textPrinterWindow and docDisplayWindow are already released on second call, but the original values is still there.
The easy fix for this issue is setting the released pointers to NULL, so that delete doesn't crash.