### PR TITLE
new Qt Serial Backend + setting DTR + RTS for better Arduino compatibility

### DIFF
--- a/optionsdialog.h
+++ b/optionsdialog.h
@@ -33,12 +33,14 @@ protected:
 
 private:
     Ui::OptionsDialog *m_ui;
-    QTreeWidgetItem *itemStandard, *itemAtariSio, *itemEmulation, *itemI18n;
+    QTreeWidgetItem *itemStandard, *itemQt, *itemAtariSio, *itemEmulation, *itemI18n;
 
 private slots:
     void on_serialPortHandshakeCombo_currentIndexChanged(int index);
+    void on_QtSerialPortHandshakeCombo_currentIndexChanged(int index);
     void on_useEmulationCustomCasBaudBox_toggled(bool checked);
     void on_serialPortUseDivisorsBox_toggled(bool checked);
+    void on_QtSerialPortUseDivisorsBox_toggled(bool checked);
     void on_treeWidget_itemClicked(QTreeWidgetItem* item, int column);
     void on_treeWidget_currentItemChanged(QTreeWidgetItem* current, QTreeWidgetItem* previous);
     void OptionsDialog_accepted();

--- a/optionsdialog.ui
+++ b/optionsdialog.ui
@@ -68,6 +68,14 @@
     </item>
     <item>
      <property name="text">
+      <string>Qt serial port</string>
+     </property>
+     <property name="checkState">
+      <enum>Unchecked</enum>
+     </property>
+    </item>
+    <item>
+     <property name="text">
       <string>AtariSIO</string>
      </property>
      <property name="checkState">
@@ -365,6 +373,283 @@
         </item>
         <item>
          <spacer name="serialPortSpacer1">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+   <widget class="QWidget" name="page_QtSerialPort">
+    <layout class="QVBoxLayout" name="verticalLayout_6">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QGroupBox" name="QtSerialPortGroup">
+       <property name="title">
+        <string>Qt serial port backend options</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_7">
+        <item>
+         <widget class="QCheckBox" name="QtSerialPortBox">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Use this backend</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="QtSerialPortDeviceNameLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Port name:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="QtSerialPortDeviceNameEdit">
+          <property name="text">
+           <string>COM1</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="QtSerialPortHandshakeLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Handshake method:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="QtSerialPortHandshakeCombo">
+          <item>
+           <property name="text">
+            <string>RI</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>DSR</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>CTS</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>NONE</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>SOFTWARE (SIO2BT)</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="QtSerialPortWriteDelayLabel">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Write delay [ms]:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="QtSerialPortWriteDelayCombo">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="currentIndex">
+           <number>1</number>
+          </property>
+          <item>
+           <property name="text">
+            <string>0</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>10</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>20</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>30</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>40</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>50</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>60</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="QtSerialPortBaudLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>High speed mode baud rate:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="QtSerialPortBaudCombo">
+          <property name="currentIndex">
+           <number>2</number>
+          </property>
+          <item>
+           <property name="text">
+            <string>19200 (1x)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>38400 (2x)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>57600 (3x)</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="QtSerialPortUseDivisorsBox">
+          <property name="text">
+           <string>Use non-standard speeds</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="QtSerialPortDivisorLabel">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>High speed mode POKEY divisor:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="QtSerialPortDivisorEdit">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="maximum">
+           <number>40</number>
+          </property>
+          <property name="value">
+           <number>6</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="QtSerialPortCompErrDelayLabel">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;Complete/Error response delay (μs)&lt;br&gt;See manual for more information&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="QtSerialPortCompErrDelayBox">
+          <property name="suffix">
+           <string>μs</string>
+          </property>
+          <property name="minimum">
+           <number>250</number>
+          </property>
+          <property name="maximum">
+           <number>2000</number>
+          </property>
+          <property name="singleStep">
+           <number>10</number>
+          </property>
+          <property name="value">
+           <number>800</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="QtSerialPortSpacer1">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>

--- a/respeqt.pro
+++ b/respeqt.pro
@@ -10,11 +10,11 @@
 # know the specific year(s) please let the current maintainer know.
 #
 #CONFIG(release, debug|release):DEFINES += QT_NO_DEBUG_OUTPUT
-DEFINES += VERSION=\\\"R3\\\"
+DEFINES += VERSION=\\\"R4-RC2\\\"
 TARGET = RespeQt
 TEMPLATE = app
 CONFIG += qt
-QT += core gui network widgets printsupport
+QT += core gui network widgets printsupport serialport
 CONFIG += mobility
 MOBILITY = bearer
 INCLUDEPATH += $$[QT_INSTALL_HEADERS]/QtZlib
@@ -42,7 +42,8 @@ SOURCES += main.cpp \
     respeqtsettings.cpp \
     drivewidget.cpp \
     pclink.cpp \
-    infowidget.cpp
+    infowidget.cpp \
+    serialport-Qt.cpp
 win32:LIBS += -lwinmm -lz
 unix:LIBS += -lz
 win32:SOURCES += serialport-win32.cpp
@@ -71,7 +72,8 @@ HEADERS += mainwindow.h \
     respeqtsettings.h \
     drivewidget.h \
     pclink.h \
-    infowidget.h
+    infowidget.h \
+    serialport-Qt.h
 
 win32:HEADERS += serialport-win32.h
 unix:HEADERS += serialport-unix.h

--- a/respeqtsettings.h
+++ b/respeqtsettings.h
@@ -46,11 +46,32 @@ public:
     int serialPortPokeyDivisor();
     void setSerialPortPokeyDivisor(int divisor);
 
-    bool useHighSpeedExeLoader();
-    void setUseHighSpeedExeLoader(bool use);
+    int serialPortWriteDelay();
+    void setSerialPortWriteDelay(int delay);
 
-    bool printerEmulation();
-    void setPrinterEmulation(bool status);
+    int serialPortCompErrDelay();
+    void setSerialPortCompErrDelay(int delay);
+
+    QString QtSerialPortName();
+    void setQtSerialPortName(const QString &name);
+
+    int QtSerialPortHandshakingMethod();
+    void setQtSerialPortHandshakingMethod(int method);
+
+    int QtSerialPortMaximumSpeed();
+    void setQtSerialPortMaximumSpeed(int speed);
+
+    bool QtSerialPortUsePokeyDivisors();
+    void setQtSerialPortUsePokeyDivisors(bool use);
+
+    int QtSerialPortPokeyDivisor();
+    void setQtSerialPortPokeyDivisor(int divisor);
+
+    int QtSerialPortWriteDelay();
+    void setQtSerialPortWriteDelay(int delay);
+
+    int QtSerialPortCompErrDelay();
+    void setQtSerialPortCompErrDelay(int delay);
 
     QString atariSioDriverName();
     void setAtariSioDriverName(const QString &name);
@@ -58,14 +79,14 @@ public:
     int atariSioHandshakingMethod();
     void setAtariSioHandshakingMethod(int method);
 
-    int serialPortWriteDelay();
-    void setSerialPortWriteDelay(int delay);
-
-    int serialPortCompErrDelay();
-    void setSerialPortCompErrDelay(int delay);
-
     int backend();
     void setBackend(int backend);
+
+    bool useHighSpeedExeLoader();
+    void setUseHighSpeedExeLoader(bool use);
+
+    bool printerEmulation();
+    void setPrinterEmulation(bool status);
 
     bool useCustomCasBaud();
     void setUseCustomCasBaud(bool use);
@@ -222,6 +243,14 @@ private:
     int mSerialPortMaximumSpeed;
     bool mSerialPortUsePokeyDivisors;
     int mSerialPortPokeyDivisor;
+
+    QString mQtSerialPortName;
+    int mQtSerialPortHandshakingMethod;
+    int mQtSerialPortWriteDelay;
+    int mQtSerialPortCompErrDelay;
+    int mQtSerialPortMaximumSpeed;
+    bool mQtSerialPortUsePokeyDivisors;
+    int mQtSerialPortPokeyDivisor;
 
     bool mUseHighSpeedExeLoader;
     bool mPrinterEmulation;

--- a/serialport-Qt.cpp
+++ b/serialport-Qt.cpp
@@ -1,0 +1,533 @@
+/*
+ * serialport-Qt.cpp
+ *
+ * TheMontezuma
+ *
+ */
+
+#include "serialport-Qt.h"
+#include <QtSerialPort/QtSerialPort>
+#include "errno.h"
+#include "sioworker.h"
+#include "respeqtsettings.h"
+
+const int MSECS_TIMEOUT = 300;
+
+
+QtSerialPortBackend::QtSerialPortBackend(QObject *parent)
+    : AbstractSerialPortBackend(parent),
+      mCanceled(false),
+      mHighSpeed(false)
+{
+}
+
+QtSerialPortBackend::~QtSerialPortBackend()
+{
+    if (isOpen()) {
+        close();
+    }
+}
+
+QString QtSerialPortBackend::defaultPortName()
+{
+    return QString("COM1");
+}
+
+bool QtSerialPortBackend::open()
+{
+    if (isOpen()) {
+        close();
+    }
+
+    QString name = respeqtSettings->QtSerialPortName();
+    mMethod = respeqtSettings->QtSerialPortHandshakingMethod();
+    mWriteDelay = SLEEP_FACTOR * respeqtSettings->QtSerialPortWriteDelay();
+    mCompErrDelay = respeqtSettings->QtSerialPortCompErrDelay();
+
+    if (!setNormalSpeed()) {
+        return false;
+    }
+
+    mSerial.setPortName(name);
+    mSerial.setDataBits(QSerialPort::Data8);
+    mSerial.setStopBits(QSerialPort::OneStop);
+    mSerial.setParity(QSerialPort::NoParity);
+    mSerial.setFlowControl(QSerialPort::NoFlowControl);
+
+    if (!mSerial.open(QIODevice::ReadWrite))
+    {
+        qCritical() << "!e" << tr("Cannot open serial port '%1': %2").arg(name, lastErrorMessage());
+        return false;
+    }
+
+    mSerial.flush();
+    mSerial.setDataTerminalReady(true);
+    mSerial.setRequestToSend(true);
+
+    mCanceled = false;
+
+    QString m;
+    switch (mMethod) {
+    case HANDSHAKE_RI:
+        m = "RI";
+        break;
+    case HANDSHAKE_DSR:
+        m = "DSR";
+        break;
+    case HANDSHAKE_CTS:
+        m = "CTS";
+        break;
+    case HANDSHAKE_NO_HANDSHAKE:
+        m = "NO";
+        break;
+    case HANDSHAKE_SOFTWARE:
+    default:
+        m = "SOFTWARE (SIO2BT)";
+        break;
+    }
+    /* Notify the user that emulation is started */
+    qWarning() << "!i" << tr("Emulation started through Qt serial port backend on '%1' with %2 handshaking.")
+                  .arg(name)
+                  .arg(m);
+    return true;
+}
+
+bool QtSerialPortBackend::isOpen()
+{
+    return mSerial.isOpen();
+}
+
+void QtSerialPortBackend::close()
+{
+    mSerial.close();
+}
+
+void QtSerialPortBackend::cancel()
+{
+    mCanceled = true;
+}
+
+int QtSerialPortBackend::speedByte()
+{
+    if (respeqtSettings->QtSerialPortHandshakingMethod()==HANDSHAKE_SOFTWARE) {
+        return 0x28; // standard speed (19200)
+    } else if (respeqtSettings->QtSerialPortUsePokeyDivisors()) {
+        return respeqtSettings->QtSerialPortPokeyDivisor();
+    } else {
+        int speed = 0x08;
+        switch (respeqtSettings->QtSerialPortMaximumSpeed()) {
+        case 0:
+            speed = 0x28;
+            break;
+        case 1:
+            speed = 0x10;
+            break;
+        case 2:
+            speed = 0x08;
+            break;
+        }
+        return speed;
+    }
+}
+
+QByteArray QtSerialPortBackend::readCommandFrame()
+{
+    QByteArray data;
+    if(mMethod==HANDSHAKE_SOFTWARE)
+    {
+        mSerial.clear(QSerialPort::Input);
+
+        const int size = 4;
+        quint8 expected = 0;
+        quint8 got = 1;
+        do
+        {
+            if( mSerial.waitForReadyRead(MSECS_TIMEOUT) )
+            {
+                QByteArray all = mSerial.readAll();
+
+                for(int i=0 ; i<all.size() ; i++)
+                {
+                    char c = all[i];
+                    data.append(c);
+                    if(data.size()==size+2)
+                    {
+                        data.remove(0,1);
+                    }
+                    if(data.size()==size+1)
+                    {
+                        for(int i=0 ; i<mSioDevices.size() ; i++)
+                        {
+                            if(data.at(0)==mSioDevices[i])
+                            {
+                                expected = (quint8)data.at(size);
+                                got = sioChecksum(data, size);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+        } while(!mCanceled && got!=expected);
+
+        if(got==expected)
+        {
+            data.resize(size);
+            // After sending the last byte of the command frame
+            // ATARI does not drop the command line immediately.
+            // Within this small time window ATARI is not able to process the ACK byte.
+            // For the "software handshake" approach, we need to wait here a little bit.
+            QThread::usleep(500);
+        }
+        else
+        {
+            data.clear();
+        }
+    }
+    else
+    {
+        QSerialPort::PinoutSignal mask;
+        switch (mMethod) {
+        case HANDSHAKE_RI:
+            mask = QSerialPort::RingIndicatorSignal;
+            break;
+        case HANDSHAKE_DSR:
+            mask = QSerialPort::DataSetReadySignal;
+            break;
+        case HANDSHAKE_CTS:
+        default:
+            mask = QSerialPort::ClearToSendSignal;
+            break;
+        }
+
+        int status;
+        int retries = 0, totalRetries = 0;
+
+        do {
+            data.clear();
+
+            if(mMethod == HANDSHAKE_NO_HANDSHAKE)
+            {
+                mSerial.clear(QSerialPort::Input);
+                while( !mCanceled && !mSerial.waitForReadyRead(MSECS_TIMEOUT));
+            }
+            else
+            {
+                // RI/DSR/CTS handshake
+
+                /* First, wait until command line goes off */
+                do {
+                    status = mSerial.pinoutSignals();
+                    if (status & mask)
+                    {
+                            QThread::usleep(500);
+                    }
+                } while (!mCanceled && (status & mask));
+
+                /* Now wait for it to go on again */
+                do {
+                    status = mSerial.pinoutSignals();
+                    if((status & mask)==0)
+                    {
+                            QThread::usleep(500);
+                    }
+                } while (!mCanceled && (status & mask)==0);
+
+                mSerial.clear(QSerialPort::Input);
+            }
+
+            if (mCanceled) {
+                return data;
+            }
+
+            data = readDataFrame(4, false, (mMethod == HANDSHAKE_NO_HANDSHAKE));
+
+            if (!data.isEmpty())
+            {
+                if(mMethod != HANDSHAKE_NO_HANDSHAKE)
+                {
+                    // wait for command line to go off
+                    do {
+                        status = mSerial.pinoutSignals();
+                        if (status & mask)
+                        {
+                                QThread::usleep(500);
+                        }
+                    } while (!mCanceled && (status & mask));
+                }
+                else
+                {
+                    // After sending the last byte of the command frame
+                    // ATARI does not drop the command line immediately.
+                    // Within this small time window ATARI is not able to process the ACK byte.
+                    // For the "no handshake" approach, we need to wait here a little bit.
+                    QThread::usleep(500);
+                }
+                break;
+            }
+            else
+            {
+                retries++;
+                totalRetries++;
+                if (retries == 2) {
+                    retries = 0;
+                    if (mHighSpeed) {
+                        setNormalSpeed();
+                    } else {
+                        setHighSpeed();
+                    }
+                }
+            }
+        } while (!mCanceled);
+    }
+    return data;
+}
+
+QByteArray QtSerialPortBackend::readDataFrame(uint size, bool verbose)
+{
+    return readDataFrame(size, verbose, false);
+}
+
+QByteArray QtSerialPortBackend::readDataFrame(uint size, bool verbose, bool skip_initial_wait)
+{
+    QByteArray data = readRawFrame(size + 1, skip_initial_wait);
+    if (data.isEmpty()) {
+        return data;
+    }
+    quint8 expected = (quint8)data.at(size);
+    quint8 got = sioChecksum(data, size);
+    if (expected == got)
+    {
+        data.resize(size);
+        return data;
+    }
+    else
+    {
+        if(verbose)
+        {
+            qWarning() << "!w" << tr("Data frame checksum error, expected: %1, got: %2. (%3)")
+                           .arg(expected)
+                           .arg(got)
+                           .arg(QString(data.toHex()));
+        }
+        data.clear();
+        return data;
+    }
+}
+
+bool QtSerialPortBackend::writeDataFrame(const QByteArray& data)
+{
+    QByteArray copy(data);
+    copy.resize(copy.size() + 1);
+    copy[copy.size() - 1] = sioChecksum(copy, copy.size() - 1);
+    if(mMethod==HANDSHAKE_SOFTWARE)SioWorker::usleep(mWriteDelay);
+    SioWorker::usleep(50);
+    return writeRawFrame(copy);
+}
+
+bool QtSerialPortBackend::writeCommandAck()
+{
+    return writeRawFrame(QByteArray(1, SIO_ACK));
+}
+
+bool QtSerialPortBackend::writeCommandNak()
+{
+    return writeRawFrame(QByteArray(1, SIO_NACK));
+}
+
+bool QtSerialPortBackend::writeDataAck()
+{
+    return writeRawFrame(QByteArray(1, SIO_ACK));
+}
+
+bool QtSerialPortBackend::writeDataNak()
+{
+    return writeRawFrame(QByteArray(1, SIO_NACK));
+}
+
+bool QtSerialPortBackend::writeComplete()
+{
+    if(mMethod==HANDSHAKE_SOFTWARE)SioWorker::usleep(mWriteDelay);
+    else SioWorker::usleep(mCompErrDelay);
+    return writeRawFrame(QByteArray(1, SIO_COMPLETE));
+}
+
+bool QtSerialPortBackend::writeError()
+{
+    if(mMethod==HANDSHAKE_SOFTWARE)SioWorker::usleep(mWriteDelay);
+    else SioWorker::usleep(mCompErrDelay);
+    return writeRawFrame(QByteArray(1, SIO_ERROR));
+}
+
+bool QtSerialPortBackend::setSpeed(int speed)
+{
+    bool result;
+    bool wasOpen = isOpen();
+    if (wasOpen)
+    {
+        mSerial.close();
+    }
+
+    result = mSerial.setBaudRate(speed);
+    if (wasOpen && !mSerial.open(QIODevice::ReadWrite))
+    {
+        return false;
+    }
+
+    if(result)
+    {
+        mSpeed = speed;
+        emit statusChanged(tr("%1 bits/sec").arg(speed));
+    }
+    return result;
+}
+
+bool QtSerialPortBackend::writeRawFrame(const QByteArray& data)
+{
+    int result;
+    uint total, rest;
+
+    total = 0;
+    rest = data.count();
+    QTime startTime = QTime::currentTime();
+
+    int timeOut = data.count() * 12000 / mSpeed + 100;
+    if(mMethod==HANDSHAKE_SOFTWARE)
+    {
+        timeOut += 100;
+    }
+
+    int elapsed;
+    do {
+        result = mSerial.write(data.constData() + total, rest);
+
+        if (result < 0 && errno != EAGAIN) {
+            qCritical() << "!e" << tr("Cannot read from serial port: %1")
+                           .arg(lastErrorMessage());
+            return false;
+        }
+        if (result < 0) {
+            result = 0;
+        }
+        total += result;
+        rest -= result;
+        elapsed = startTime.msecsTo(QTime::currentTime());
+    } while (total < (uint)data.count() && elapsed < timeOut);
+
+    if (total != (uint)data.count())
+    {
+        qCritical() << "!e" << tr("Serial port write timeout. %1 of %2 written in %3 ms").arg(total).arg(data.count()).arg(elapsed);
+        return false;
+    }
+    mSerial.waitForBytesWritten(MSECS_TIMEOUT);
+    return true;
+}
+
+void QtSerialPortBackend::setActiveSioDevices(const QByteArray& data)
+{
+    mSioDevices = data;
+}
+
+bool QtSerialPortBackend::setNormalSpeed()
+{
+    mHighSpeed = false;
+    return setSpeed(19200);
+}
+
+bool QtSerialPortBackend::setHighSpeed()
+{
+    mHighSpeed = true;
+    if (respeqtSettings->QtSerialPortUsePokeyDivisors()) {
+        return setSpeed(divisorToBaud(respeqtSettings->QtSerialPortPokeyDivisor()));
+    } else {
+        int speed = 57600;
+        switch (respeqtSettings->QtSerialPortMaximumSpeed()) {
+        case 0:
+            speed = 19200;
+            break;
+        case 1:
+            speed = 38400;
+            break;
+        case 2:
+            speed = 57600;
+            break;
+        }
+        return setSpeed(speed);
+    }
+}
+
+int QtSerialPortBackend::speed()
+{
+    return mSpeed;
+}
+
+quint8 QtSerialPortBackend::sioChecksum(const QByteArray &data, uint size)
+{
+    uint i;
+    uint sum = 0;
+
+    for (i=0; i < size; i++) {
+        sum += (quint8)data.at(i);
+        if (sum > 255) {
+            sum -= 255;
+        }
+    }
+
+    return sum;
+}
+
+QByteArray QtSerialPortBackend::readRawFrame(uint size, bool skip_initial_wait)
+{
+    QByteArray data;
+    int result;
+    uint total, rest;
+
+    data.resize(size);
+
+    total = 0;
+    rest = size;
+    QTime startTime = QTime::currentTime();
+
+    int timeOut = data.count() * 12000 / mSpeed + 100;
+    if(mMethod==HANDSHAKE_SOFTWARE)
+    {
+        timeOut += 100;
+    }
+
+    int elapsed;
+    do
+    {
+        if(!skip_initial_wait || total!=0)
+        {
+            mSerial.waitForReadyRead(MSECS_TIMEOUT);
+        }
+        result = mSerial.read(data.data() + total, rest);
+        if (result < 0 && errno != EAGAIN) {
+            qCritical() << "!e" << tr("Cannot read from serial port: %1")
+                           .arg(lastErrorMessage());
+            data.clear();
+            return data;
+        }
+        if (result < 0) {
+            result = 0;
+        }
+        total += result;
+        rest -= result;
+        elapsed = startTime.msecsTo(QTime::currentTime());
+    } while (total < size && elapsed < timeOut);
+
+    if ((uint)total != size)
+    {
+        qCritical() << "!e" << tr("Serial port read timeout. %1 of %2 read in %3 ms").arg(total).arg(data.count()).arg(elapsed);
+        data.clear();
+        return data;
+    }
+    return data;
+}
+
+QString QtSerialPortBackend::lastErrorMessage()
+{
+    return QString::fromUtf8(strerror(errno)) + ".";
+}
+

--- a/serialport-Qt.h
+++ b/serialport-Qt.h
@@ -1,0 +1,63 @@
+/*
+ * serialport-Qt.h
+ *
+ * Copyright 2016 TheMontezuma
+ *
+ * This file is copyrighted by either Fatih Aygun, Ray Ataergin, or both.
+ * However, the years for these copyrights are unfortunately unknown. If you
+ * know the specific year(s) please let the current maintainer know.
+ */
+
+#ifndef SERIALPORT_QT_H
+#define SERIALPORT_QT_H
+
+#include "serialport.h"
+#include <QtSerialPort/QSerialPort>
+
+class QtSerialPortBackend : public AbstractSerialPortBackend
+{
+    Q_OBJECT
+
+public:
+    static QString defaultPortName();
+
+    QtSerialPortBackend(QObject *parent = 0);
+    ~QtSerialPortBackend();
+    bool open();
+    bool isOpen();
+    void close();
+    void cancel();
+    int speedByte();
+    QByteArray readCommandFrame();
+    QByteArray readDataFrame(uint size, bool verbose=false);
+    bool writeDataFrame(const QByteArray &data);
+    bool writeCommandAck();
+    bool writeCommandNak();
+    bool writeDataAck();
+    bool writeDataNak();
+    bool writeComplete();
+    bool writeError();
+    bool setSpeed(int speed);
+    bool writeRawFrame(const QByteArray &data);
+    void setActiveSioDevices(const QByteArray &data);
+
+private:
+    bool setNormalSpeed();
+    bool setHighSpeed();
+    int speed();
+    quint8 sioChecksum(const QByteArray &data, uint size);
+    QByteArray readDataFrame(uint size, bool verbose, bool skip_initial_wait);
+    QByteArray readRawFrame(uint size, bool skip_initial_wait);
+    QString lastErrorMessage();
+
+    QSerialPort mSerial;
+    bool mCanceled;
+    bool mHighSpeed;
+    int mSpeed;
+    int mMethod;
+    int mWriteDelay;
+    int mCompErrDelay;
+    QByteArray mSioDevices;
+};
+
+#endif // SERIALPORT_QT_H

--- a/serialport-unix.cpp
+++ b/serialport-unix.cpp
@@ -98,9 +98,9 @@ bool StandardSerialPortBackend::open()
             qCritical() << "!e" << tr("Cannot get serial port status");
             return false;
         }
-        status = status & ~(TIOCM_RI | TIOCM_RTS | TIOCM_CTS);
+        status |= (TIOCM_DTR | TIOCM_RTS);
         if (ioctl(mHandle, TIOCMSET, &status) < 0) {
-            qCritical() << "!e" << tr("Cannot clear RI, RTS and CTS lines in serial port '%1': %2").arg(name, lastErrorMessage());
+            qCritical() << "!e" << tr("Cannot set DTR and RTS lines in serial port '%1': %2").arg(name, lastErrorMessage());
             return false;
         }
     }
@@ -541,36 +541,36 @@ bool StandardSerialPortBackend::writeDataFrame(const QByteArray &data)
 
 bool StandardSerialPortBackend::writeCommandAck()
 {
-    return writeRawFrame(QByteArray(1, 65));
+    return writeRawFrame(QByteArray(1, SIO_ACK));
 }
 
 bool StandardSerialPortBackend::writeCommandNak()
 {
-    return writeRawFrame(QByteArray(1, 78));
+    return writeRawFrame(QByteArray(1, SIO_NACK));
 }
 
 bool StandardSerialPortBackend::writeDataAck()
 {
-    return writeRawFrame(QByteArray(1, 65));
+    return writeRawFrame(QByteArray(1, SIO_ACK));
 }
 
 bool StandardSerialPortBackend::writeDataNak()
 {
-    return writeRawFrame(QByteArray(1, 78));
+    return writeRawFrame(QByteArray(1, SIO_NACK));
 }
 
 bool StandardSerialPortBackend::writeComplete()
 {
     if(mMethod==HANDSHAKE_SOFTWARE)SioWorker::usleep(mWriteDelay);
     else SioWorker::usleep(mCompErrDelay);
-    return writeRawFrame(QByteArray(1, 67));
+    return writeRawFrame(QByteArray(1, SIO_COMPLETE));
 }
 
 bool StandardSerialPortBackend::writeError()
 {
     if(mMethod==HANDSHAKE_SOFTWARE)SioWorker::usleep(mWriteDelay);
     else SioWorker::usleep(mCompErrDelay);
-    return writeRawFrame(QByteArray(1, 69));
+    return writeRawFrame(QByteArray(1, SIO_ERROR));
 }
 
 quint8 StandardSerialPortBackend::sioChecksum(const QByteArray &data, uint size)

--- a/serialport-win32.cpp
+++ b/serialport-win32.cpp
@@ -70,7 +70,7 @@ bool StandardSerialPortBackend::open()
             0,
             NULL,
             OPEN_EXISTING,
-            FILE_FLAG_WRITE_THROUGH,
+            0,
             0
         ));
         if (mHandle == INVALID_HANDLE_VALUE) {
@@ -93,12 +93,12 @@ bool StandardSerialPortBackend::open()
             qCritical() << "!e" << tr("Cannot open serial port '%1': %2").arg(respeqtSettings->serialPortName(), lastErrorMessage());
             return false;
         }
-        if (!EscapeCommFunction(mHandle, CLRRTS)) {
-            qCritical() << "!e" << tr("Cannot clear RTS line in serial port '%1': %2").arg(respeqtSettings->serialPortName(), lastErrorMessage());
+        if (!EscapeCommFunction(mHandle, SETDTR)) {
+            qCritical() << "!e" << tr("Cannot set DTR line in serial port '%1': %2").arg(respeqtSettings->serialPortName(), lastErrorMessage());
             return false;
         }
-        if (!EscapeCommFunction(mHandle, CLRDTR)) {
-            qCritical() << "!e" << tr("Cannot clear DTR line in serial port '%1': %2").arg(respeqtSettings->serialPortName(), lastErrorMessage());
+        if (!EscapeCommFunction(mHandle, SETRTS)) {
+            qCritical() << "!e" << tr("Cannot set RTS line in serial port '%1': %2").arg(respeqtSettings->serialPortName(), lastErrorMessage());
             return false;
         }
     }
@@ -231,14 +231,14 @@ bool StandardSerialPortBackend::setSpeed(int speed)
 
     dcb.fOutxCtsFlow = FALSE;
     dcb.fOutxDsrFlow = FALSE;
-    dcb.fDtrControl = DTR_CONTROL_DISABLE;
+    dcb.fDtrControl = DTR_CONTROL_ENABLE;
     dcb.fDsrSensitivity = FALSE;
     dcb.fTXContinueOnXoff = FALSE;
     dcb.fOutX = FALSE;
     dcb.fInX = FALSE;
     dcb.fErrorChar = FALSE;
     dcb.fNull = FALSE;
-    dcb.fRtsControl = RTS_CONTROL_DISABLE;
+    dcb.fRtsControl = RTS_CONTROL_ENABLE;
     dcb.fAbortOnError = FALSE;
     dcb.fDummy2 = 0;
     dcb.wReserved = 0;
@@ -512,28 +512,28 @@ bool StandardSerialPortBackend::writeCommandAck()
 {
 //    qDebug() << "!d" << tr("DBG -- Serial Port writeCommandAck...");
 
-    return writeRawFrame(QByteArray(1, 65));
+    return writeRawFrame(QByteArray(1, SIO_ACK));
 }
 
 bool StandardSerialPortBackend::writeCommandNak()
 {
 //    qDebug() << "!d" << tr("DBG -- Serial Port writeCommandNak...");
 
-    return writeRawFrame(QByteArray(1, 78));
+    return writeRawFrame(QByteArray(1, SIO_NACK));
 }
 
 bool StandardSerialPortBackend::writeDataAck()
 {
 //    qDebug() << "!d" << tr("DBG -- Serial Port writeDataAck...");
 
-    return writeRawFrame(QByteArray(1, 65));
+    return writeRawFrame(QByteArray(1, SIO_ACK));
 }
 
 bool StandardSerialPortBackend::writeDataNak()
 {
 //    qDebug() << "!d" << tr("DBG -- Serial Port writeDataNak...");
 
-    return writeRawFrame(QByteArray(1, 78));
+    return writeRawFrame(QByteArray(1, SIO_NACK));
 }
 
 bool StandardSerialPortBackend::writeComplete()
@@ -542,7 +542,7 @@ bool StandardSerialPortBackend::writeComplete()
 
     if(mMethod==HANDSHAKE_SOFTWARE)SioWorker::usleep(mWriteDelay);
     else SioWorker::usleep(mCompErrDelay);
-    return writeRawFrame(QByteArray(1, 67));
+    return writeRawFrame(QByteArray(1, SIO_COMPLETE));
 }
 
 bool StandardSerialPortBackend::writeError()
@@ -551,7 +551,7 @@ bool StandardSerialPortBackend::writeError()
 
     if(mMethod==HANDSHAKE_SOFTWARE)SioWorker::usleep(mWriteDelay);
     else SioWorker::usleep(mCompErrDelay);
-    return writeRawFrame(QByteArray(1, 69));
+    return writeRawFrame(QByteArray(1, SIO_ERROR));
 }
 
 quint8 StandardSerialPortBackend::sioChecksum(const QByteArray &data, uint size)

--- a/serialport.h
+++ b/serialport.h
@@ -23,6 +23,21 @@ enum eHandshake
     HANDSHAKE_SOFTWARE=4
 };
 
+enum eSerialBackend
+{
+    SERIAL_BACKEND_STANDARD=0,
+    SERIAL_BACKEND_QT=1,
+    SERIAL_BACKEND_SIO_DRIVER=2
+};
+
+enum eSIOConstants
+{
+    SIO_ACK = 65,
+    SIO_NACK = 78,
+    SIO_COMPLETE = 67,
+    SIO_ERROR = 69
+};
+
 #define SLEEP_FACTOR 10000
 
 class AbstractSerialPortBackend : public QObject
@@ -80,5 +95,6 @@ signals:
 #ifdef Q_OS_UNIX
 #include "serialport-unix.h"
 #endif
+#include "serialport-Qt.h"
 
 #endif // SERIALPORT_H

--- a/sioworker.cpp
+++ b/sioworker.cpp
@@ -79,10 +79,13 @@ bool SioWorker::wait(unsigned long time)
 void SioWorker::start(Priority p)
 {
     switch (respeqtSettings->backend()) {
-        case 0:
+        case SERIAL_BACKEND_STANDARD:
             mPort = new StandardSerialPortBackend(0);
             break;
-        case 1:
+        case SERIAL_BACKEND_QT:
+            mPort = new QtSerialPortBackend(0);
+            break;
+        case SERIAL_BACKEND_SIO_DRIVER:
             mPort = new AtariSioBackend(0);
             break;
     }
@@ -456,10 +459,13 @@ void CassetteWorker::run()
 void CassetteWorker::start(Priority p)
 {
     switch (respeqtSettings->backend()) {
-        case 0:
+        case SERIAL_BACKEND_STANDARD:
             mPort = new StandardSerialPortBackend(0);
             break;
-        case 1:
+        case SERIAL_BACKEND_QT:
+            mPort = new QtSerialPortBackend(0);
+            break;
+        case SERIAL_BACKEND_SIO_DRIVER:
             mPort = new AtariSioBackend(0);
             break;
     }


### PR DESCRIPTION
- new backend added based on the Qt implementation of the serial port
- set DTR and RTS output lines on opening of the serial port (to support "Arduino Pro Micro" as SIO2PC)

The new backend is based on the Qt serial port abstraction.
This means the same RespeQt code is used for handling low level communication under Windows, Linux or Mac. At the end, the QSerialPort implementation uses native API of the corresponding OS, like it is done in the Standard Backend right now. From the first point of view, you may see no benefit of introducing new backend, but the benefit is that if the user encounters any problem with the native implementation of the Standard Backend (which will of course will not be removed from the project), he can switch the backend and perhaps have better luck with the Qt code.
At the time of writing of the AspeQt, there was no serial port support in the Qt, so there was no other choice, as to write it on your own. Today we can benefit of having two approaches :)

Setting the DTR/RTS line occurred to be necessary when using Arduino Micro Pro (as a SIO2PC).
There is a new project called SIO CART which is using this hardware and they wanted to make the USB port usefull for users.
