### PR TITLE
serial port backend for testing

### DIFF
--- a/optionsdialog.cpp
+++ b/optionsdialog.cpp
@@ -31,9 +31,15 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
     itemAtariSio = m_ui->treeWidget->topLevelItem(0)->child(1);
     itemEmulation = m_ui->treeWidget->topLevelItem(1);
     itemI18n = m_ui->treeWidget->topLevelItem(2);
+#ifndef Q_NO_DEBUG
+    itemTestSerialPort = m_ui->treeWidget->topLevelItem(0)->child(2);
+#endif
 
 #ifndef Q_OS_LINUX
     m_ui->treeWidget->topLevelItem(0)->removeChild(itemAtariSio);
+#endif
+#ifdef Q_NO_DEBUG
+    m_ui->treeWidget->topLevelItem(0)->removeChild(itemTestSerialPort);
 #endif
 
     connect(this, SIGNAL(accepted()), this, SLOT(OptionsDialog_accepted()));
@@ -78,14 +84,23 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
     m_ui->enableShade->setChecked(respeqtSettings->enableShade());
 
     switch (respeqtSettings->backend()) {
+#ifndef Q_NO_DEBUG
+        case SERIAL_BACKEND_TEST:
+#endif
         case SERIAL_BACKEND_STANDARD:
             itemStandard->setCheckState(0, Qt::Checked);
             itemAtariSio->setCheckState(0, Qt::Unchecked);
+#ifndef Q_NO_DEBUG
+            itemTestSerialPort->setCheckState(0, Qt::Unchecked);
+#endif
             m_ui->treeWidget->setCurrentItem(itemStandard);
             break;
         case SERIAL_BACKEND_SIO_DRIVER:
             itemStandard->setCheckState(0, Qt::Unchecked);
             itemAtariSio->setCheckState(0, Qt::Checked);
+#ifndef Q_NO_DEBUG
+            itemTestSerialPort->setCheckState(0, Qt::Unchecked);
+#endif
             m_ui->treeWidget->setCurrentItem(itemAtariSio);
             break;
     }
@@ -203,6 +218,12 @@ void OptionsDialog::on_treeWidget_itemClicked(QTreeWidgetItem* item, int /*colum
         {
             itemAtariSio->setCheckState(0, Qt::Unchecked);
         }
+#ifndef Q_NO_DEBUG
+        if (item != itemTestSerialPort)
+        {
+            itemTestSerialPort->setCheckState(0, Qt::Unchecked);
+        }
+#endif
     }
     else if ((itemStandard->checkState(0) == Qt::Unchecked) &&
             (itemAtariSio->checkState(0) == Qt::Unchecked))
@@ -211,6 +232,9 @@ void OptionsDialog::on_treeWidget_itemClicked(QTreeWidgetItem* item, int /*colum
     }
     m_ui->serialPortBox->setCheckState(itemStandard->checkState(0));
     m_ui->atariSioBox->setCheckState(itemAtariSio->checkState(0));
+#ifndef Q_NO_DEBUG
+    m_ui->serialTestBox->setCheckState(itemTestSerialPort->checkState(0));
+#endif
 }
 
 void OptionsDialog::on_treeWidget_currentItemChanged(QTreeWidgetItem* current, QTreeWidgetItem* /*previous*/)
@@ -219,10 +243,12 @@ void OptionsDialog::on_treeWidget_currentItemChanged(QTreeWidgetItem* current, Q
         m_ui->stackedWidget->setCurrentIndex(0);
     } else if (current == itemAtariSio) {
         m_ui->stackedWidget->setCurrentIndex(1);
-    } else if (current == itemEmulation) {
+    } else if (current == itemTestSerialPort) {
         m_ui->stackedWidget->setCurrentIndex(2);
+    } else if (current == itemEmulation) {
+        m_ui->stackedWidget->setCurrentIndex(3);
     } else if (current == itemI18n) {
-    m_ui->stackedWidget->setCurrentIndex(3);
+        m_ui->stackedWidget->setCurrentIndex(4);
     }
 }
 
@@ -254,6 +280,12 @@ void OptionsDialog::OptionsDialog_accepted()
     {
         backend = SERIAL_BACKEND_SIO_DRIVER;
     }
+#ifndef Q_NO_DEBUG
+    else if (itemTestSerialPort->checkState(0) == Qt::Checked)
+    {
+        backend = SERIAL_BACKEND_TEST;
+    }
+#endif
 
     respeqtSettings->setBackend(backend);
 

--- a/optionsdialog.cpp
+++ b/optionsdialog.cpp
@@ -32,15 +32,13 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
     itemAtariSio = m_ui->treeWidget->topLevelItem(0)->child(1);
     itemEmulation = m_ui->treeWidget->topLevelItem(1);
     itemI18n = m_ui->treeWidget->topLevelItem(2);
-#ifndef QT_NO_DEBUG
     itemTestSerialPort = m_ui->treeWidget->topLevelItem(0)->child(2);
-#endif
 
 #ifndef Q_OS_LINUX
     m_ui->treeWidget->topLevelItem(0)->removeChild(itemAtariSio);
 #endif
 #ifdef QT_NO_DEBUG
-    m_ui->treeWidget->topLevelItem(0)->removeChild(m_ui->treeWidget->topLevelItem(0)->child(2));
+    m_ui->treeWidget->topLevelItem(0)->removeChild(itemTestSerialPort);
 #endif
 
     connect(this, SIGNAL(accepted()), this, SLOT(OptionsDialog_accepted()));

--- a/optionsdialog.cpp
+++ b/optionsdialog.cpp
@@ -32,14 +32,14 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
     itemAtariSio = m_ui->treeWidget->topLevelItem(0)->child(1);
     itemEmulation = m_ui->treeWidget->topLevelItem(1);
     itemI18n = m_ui->treeWidget->topLevelItem(2);
-#ifndef Q_NO_DEBUG
+#ifndef QT_NO_DEBUG
     itemTestSerialPort = m_ui->treeWidget->topLevelItem(0)->child(2);
 #endif
 
 #ifndef Q_OS_LINUX
     m_ui->treeWidget->topLevelItem(0)->removeChild(itemAtariSio);
 #endif
-#ifdef Q_NO_DEBUG
+#ifdef QT_NO_DEBUG
     m_ui->treeWidget->topLevelItem(0)->removeChild(m_ui->treeWidget->topLevelItem(0)->child(2));
 #endif
 
@@ -85,13 +85,13 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
     m_ui->enableShade->setChecked(respeqtSettings->enableShade());
 
     switch (respeqtSettings->backend()) {
-#ifndef Q_NO_DEBUG
+#ifndef QT_NO_DEBUG
         case SERIAL_BACKEND_TEST:
 #endif
         case SERIAL_BACKEND_STANDARD:
             itemStandard->setCheckState(0, Qt::Checked);
             itemAtariSio->setCheckState(0, Qt::Unchecked);
-#ifndef Q_NO_DEBUG
+#ifndef QT_NO_DEBUG
             itemTestSerialPort->setCheckState(0, Qt::Unchecked);
 #endif
             m_ui->treeWidget->setCurrentItem(itemStandard);
@@ -99,7 +99,7 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
         case SERIAL_BACKEND_SIO_DRIVER:
             itemStandard->setCheckState(0, Qt::Unchecked);
             itemAtariSio->setCheckState(0, Qt::Checked);
-#ifndef Q_NO_DEBUG
+#ifndef QT_NO_DEBUG
             itemTestSerialPort->setCheckState(0, Qt::Unchecked);
 #endif
             m_ui->treeWidget->setCurrentItem(itemAtariSio);
@@ -219,7 +219,7 @@ void OptionsDialog::on_treeWidget_itemClicked(QTreeWidgetItem* item, int /*colum
         {
             itemAtariSio->setCheckState(0, Qt::Unchecked);
         }
-#ifndef Q_NO_DEBUG
+#ifndef QT_NO_DEBUG
         if (item != itemTestSerialPort)
         {
             itemTestSerialPort->setCheckState(0, Qt::Unchecked);
@@ -233,7 +233,7 @@ void OptionsDialog::on_treeWidget_itemClicked(QTreeWidgetItem* item, int /*colum
     }
     m_ui->serialPortBox->setCheckState(itemStandard->checkState(0));
     m_ui->atariSioBox->setCheckState(itemAtariSio->checkState(0));
-#ifndef Q_NO_DEBUG
+#ifndef QT_NO_DEBUG
     m_ui->serialTestBox->setCheckState(itemTestSerialPort->checkState(0));
 #endif
 }
@@ -281,7 +281,7 @@ void OptionsDialog::OptionsDialog_accepted()
     {
         backend = SERIAL_BACKEND_SIO_DRIVER;
     }
-#ifndef Q_NO_DEBUG
+#ifndef QT_NO_DEBUG
     else if (itemTestSerialPort->checkState(0) == Qt::Checked)
     {
         backend = SERIAL_BACKEND_TEST;
@@ -300,7 +300,7 @@ void OptionsDialog::on_useEmulationCustomCasBaudBox_toggled(bool checked)
 
 void OptionsDialog::on_testFileButton_clicked()
 {
-#ifndef Q_NO_DEBUG
+#ifndef QT_NO_DEBUG
     QString file1Name = QFileDialog::getOpenFileName(this,
              tr("Open test XML File"), QString(), tr("XML Files (*.xml)"));
     m_ui->testFileLabel->setText(file1Name);

--- a/optionsdialog.cpp
+++ b/optionsdialog.cpp
@@ -15,6 +15,7 @@
 #include <QtSerialPort/QtSerialPort>
 #include <QTranslator>
 #include <QDir>
+#include <QFileDialog>
 
 OptionsDialog::OptionsDialog(QWidget *parent) :
     QDialog(parent),
@@ -39,7 +40,7 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
     m_ui->treeWidget->topLevelItem(0)->removeChild(itemAtariSio);
 #endif
 #ifdef Q_NO_DEBUG
-    m_ui->treeWidget->topLevelItem(0)->removeChild(itemTestSerialPort);
+    m_ui->treeWidget->topLevelItem(0)->removeChild(m_ui->treeWidget->topLevelItem(0)->child(2));
 #endif
 
     connect(this, SIGNAL(accepted()), this, SLOT(OptionsDialog_accepted()));
@@ -295,4 +296,14 @@ void OptionsDialog::OptionsDialog_accepted()
 void OptionsDialog::on_useEmulationCustomCasBaudBox_toggled(bool checked)
 {
     m_ui->emulationCustomCasBaudSpin->setEnabled(checked);
+}
+
+void OptionsDialog::on_testFileButton_clicked()
+{
+#ifndef Q_NO_DEBUG
+    QString file1Name = QFileDialog::getOpenFileName(this,
+             tr("Open test XML File"), QString(), tr("XML Files (*.xml)"));
+    m_ui->testFileLabel->setText(file1Name);
+    respeqtSettings->setTestFile(file1Name);
+#endif
 }

--- a/optionsdialog.h
+++ b/optionsdialog.h
@@ -34,6 +34,9 @@ protected:
 private:
     Ui::OptionsDialog *m_ui;
     QTreeWidgetItem *itemStandard, *itemAtariSio, *itemEmulation, *itemI18n;
+#ifndef Q_NO_DEBUG
+    QTreeWidgetItem *itemTestSerialPort;
+#endif
 
 private slots:
     void on_serialPortComboBox_currentIndexChanged(int index);

--- a/optionsdialog.h
+++ b/optionsdialog.h
@@ -46,6 +46,7 @@ private slots:
     void on_treeWidget_currentItemChanged(QTreeWidgetItem* current, QTreeWidgetItem* previous);
     void OptionsDialog_accepted();
     void on_useEmulationCustomCasBaudBox_toggled(bool checked);
+    void on_testFileButton_clicked();
 };
 
 #endif // OPTIONSDIALOG_H

--- a/optionsdialog.h
+++ b/optionsdialog.h
@@ -34,9 +34,7 @@ protected:
 private:
     Ui::OptionsDialog *m_ui;
     QTreeWidgetItem *itemStandard, *itemAtariSio, *itemEmulation, *itemI18n;
-#ifndef QT_NO_DEBUG
     QTreeWidgetItem *itemTestSerialPort;
-#endif
 
 private slots:
     void on_serialPortComboBox_currentIndexChanged(int index);

--- a/optionsdialog.h
+++ b/optionsdialog.h
@@ -34,7 +34,7 @@ protected:
 private:
     Ui::OptionsDialog *m_ui;
     QTreeWidgetItem *itemStandard, *itemAtariSio, *itemEmulation, *itemI18n;
-#ifndef Q_NO_DEBUG
+#ifndef QT_NO_DEBUG
     QTreeWidgetItem *itemTestSerialPort;
 #endif
 

--- a/optionsdialog.ui
+++ b/optionsdialog.ui
@@ -110,7 +110,7 @@
     </sizepolicy>
    </property>
    <property name="currentIndex">
-    <number>2</number>
+    <number>0</number>
    </property>
    <widget class="QWidget" name="page_serialPort">
     <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/optionsdialog.ui
+++ b/optionsdialog.ui
@@ -110,7 +110,7 @@
     </sizepolicy>
    </property>
    <property name="currentIndex">
-    <number>0</number>
+    <number>2</number>
    </property>
    <widget class="QWidget" name="page_serialPort">
     <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -492,7 +492,7 @@
     <property name="enabled">
      <bool>true</bool>
     </property>
-    <layout class="QVBoxLayout" name="verticalLayout_2">
+    <layout class="QVBoxLayout" name="verticalLayout_6">
      <property name="spacing">
       <number>0</number>
      </property>
@@ -523,6 +523,33 @@
            <string>Use this backend</string>
           </property>
          </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <property name="bottomMargin">
+           <number>12</number>
+          </property>
+          <item>
+           <widget class="QPushButton" name="testFileButton">
+            <property name="text">
+             <string>File</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="testFileLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Select test file</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item>
          <spacer name="verticalSpacer_3">

--- a/optionsdialog.ui
+++ b/optionsdialog.ui
@@ -74,6 +74,14 @@
       <enum>Unchecked</enum>
      </property>
     </item>
+    <item>
+     <property name="text">
+      <string>Test Backend</string>
+     </property>
+     <property name="checkState">
+      <enum>Unchecked</enum>
+     </property>
+    </item>
    </item>
    <item>
     <property name="text">
@@ -471,6 +479,60 @@
            <size>
             <width>20</width>
             <height>148</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+   <widget class="QWidget" name="page_testSerialport">
+    <property name="enabled">
+     <bool>true</bool>
+    </property>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QGroupBox" name="verticalGroupBox">
+       <property name="title">
+        <string>Test backend options</string>
+       </property>
+       <layout class="QVBoxLayout" name="testSerialport">
+        <item>
+         <widget class="QCheckBox" name="serialTestBox">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Use this backend</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
            </size>
           </property>
          </spacer>

--- a/respeqt.pro
+++ b/respeqt.pro
@@ -42,7 +42,8 @@ SOURCES += main.cpp \
     respeqtsettings.cpp \
     drivewidget.cpp \
     pclink.cpp \
-    infowidget.cpp
+    infowidget.cpp \
+    serialport-test.cpp
 win32:LIBS += -lwinmm -lz
 unix:LIBS += -lz
 win32:SOURCES += serialport-win32.cpp
@@ -71,7 +72,8 @@ HEADERS += mainwindow.h \
     respeqtsettings.h \
     drivewidget.h \
     pclink.h \
-    infowidget.h
+    infowidget.h \
+    serialport-test.h
 
 win32:HEADERS += serialport-win32.h
 unix:HEADERS += serialport-unix.h
@@ -116,6 +118,9 @@ TRANSLATIONS = \
     i18n/respeqt_tr.ts
 
 RC_FILE = RespeQt.rc \
+
+DISTFILES += \
+    test.xml
 
 
 

--- a/respeqtsettings.cpp
+++ b/respeqtsettings.cpp
@@ -60,7 +60,7 @@ RespeqtSettings::RespeqtSettings()
     mAtariSioHandshakingMethod = mSettings->value("AtariSioHandshakingMethod", 0).toInt();
 
     mBackend = mSettings->value("Backend", 0).toInt();
-#ifndef Q_NO_DEBUG
+#ifndef QT_NO_DEBUG
     if (mBackend == SERIAL_BACKEND_TEST) {
         mBackend = SERIAL_BACKEND_STANDARD;
     }
@@ -133,7 +133,7 @@ void RespeqtSettings::saveSessionToFile(const QString &fileName)
     extern bool g_miniMode;
     QSettings s(fileName, QSettings::IniFormat);
 
-#ifndef Q_NO_DEBUG
+#ifndef QT_NO_DEBUG
     if (mBackend == SERIAL_BACKEND_TEST) {
         mBackend = SERIAL_BACKEND_STANDARD;
     }

--- a/respeqtsettings.cpp
+++ b/respeqtsettings.cpp
@@ -60,6 +60,11 @@ RespeqtSettings::RespeqtSettings()
     mAtariSioHandshakingMethod = mSettings->value("AtariSioHandshakingMethod", 0).toInt();
 
     mBackend = mSettings->value("Backend", 0).toInt();
+#ifndef Q_NO_DEBUG
+    if (mBackend == SERIAL_BACKEND_TEST) {
+        mBackend = SERIAL_BACKEND_STANDARD;
+    }
+#endif
 
     mUseHighSpeedExeLoader = mSettings->value("UseHighSpeedExeLoader", false).toBool();
     mPrinterEmulation = mSettings->value("PrinterEmulation", true).toBool();
@@ -127,6 +132,12 @@ void RespeqtSettings::saveSessionToFile(const QString &fileName)
 {
     extern bool g_miniMode;
     QSettings s(fileName, QSettings::IniFormat);
+
+#ifndef Q_NO_DEBUG
+    if (mBackend == SERIAL_BACKEND_TEST) {
+        mBackend = SERIAL_BACKEND_STANDARD;
+    }
+#endif
 
     s.beginGroup("RespeQt");
         s.setValue("Backend", mBackend);

--- a/respeqtsettings.h
+++ b/respeqtsettings.h
@@ -60,7 +60,7 @@ public:
 
     int backend();
     void setBackend(int backend);
-#ifndef Q_NO_DEBUG
+#ifndef QT_NO_DEBUG
     QString testFile() const { return mTestFile; }
     void setTestFile(const QString testFile) { mTestFile = testFile; }
 #endif
@@ -238,7 +238,7 @@ private:
     int mAtariSioHandshakingMethod;
 
     int mBackend;
-#ifndef Q_NO_DEBUG
+#ifndef QT_NO_DEBUG
     QString mTestFile;
 #endif
 

--- a/respeqtsettings.h
+++ b/respeqtsettings.h
@@ -60,6 +60,10 @@ public:
 
     int backend();
     void setBackend(int backend);
+#ifndef Q_NO_DEBUG
+    QString testFile() const { return mTestFile; }
+    void setTestFile(const QString testFile) { mTestFile = testFile; }
+#endif
 
     bool useHighSpeedExeLoader();
     void setUseHighSpeedExeLoader(bool use);
@@ -234,6 +238,9 @@ private:
     int mAtariSioHandshakingMethod;
 
     int mBackend;
+#ifndef Q_NO_DEBUG
+    QString mTestFile;
+#endif
 
     bool mUseCustomCasBaud;
     int mCustomCasBaud;

--- a/serialport-test.cpp
+++ b/serialport-test.cpp
@@ -1,3 +1,4 @@
+#ifndef QT_NO_DEBUG
 #include "serialport-test.h"
 #include "respeqtsettings.h"
 #include "logdisplaydialog.h"
@@ -11,7 +12,6 @@ TestSerialPortBackend::TestSerialPortBackend(QObject *parent)
     : AbstractSerialPortBackend(parent),
       mXmlReader(NULL)
 {
-    //mTestFilename = QString("/Users/jochen/work/RespeQt/test.xml");
     mTestFilename = respeqtSettings->testFile();
 }
 
@@ -242,3 +242,4 @@ bool TestSerialPortBackend::writeRawFrame(const QByteArray &/*data*/)
 
 void TestSerialPortBackend::setActiveSioDevices(const QByteArray &/*data*/)
 {}
+#endif

--- a/serialport-test.cpp
+++ b/serialport-test.cpp
@@ -1,0 +1,194 @@
+#include "serialport-test.h"
+
+#include <QFile>
+#include <exception>
+#include <QDir>
+#include "logdisplaydialog.h"
+
+TestSerialPortBackend::TestSerialPortBackend(QObject *parent)
+    : AbstractSerialPortBackend(parent),
+      mXmlReader(NULL)
+{
+    mTestFilename = QString("/Users/jochen/work/RespeQt/test.xml");
+}
+
+TestSerialPortBackend::~TestSerialPortBackend()
+{
+    if (isOpen()) {
+        close();
+    }
+}
+
+bool TestSerialPortBackend::open()
+{
+    if (isOpen()) {
+        close();
+    }
+    // Open XML and parse it
+    if (mTestFilename.size() == 0) return false;
+
+    QFile *file = new QFile(mTestFilename);
+    if (!file->exists()) return false;
+    file->open(QIODevice::Text|QFile::ReadOnly);
+
+    mXmlReader = new QXmlStreamReader(file);
+
+    if (mXmlReader->readNext() != QXmlStreamReader::StartDocument) {
+        return false;
+    }
+    if (mXmlReader->readNext() != QXmlStreamReader::StartElement) {
+        return false;
+    }
+    if (mXmlReader->name() != "testcase")
+        return false;
+
+    return true;
+}
+
+bool TestSerialPortBackend::isOpen()
+{
+    if (!mXmlReader) return false;
+    if (!mXmlReader->device()) return false;
+    return mXmlReader->device()->isOpen();
+}
+
+void TestSerialPortBackend::close()
+{
+    cancel();
+}
+
+void TestSerialPortBackend::cancel()
+{
+    if (mXmlReader)
+    {
+        mXmlReader->device()->close();
+    }
+    delete mXmlReader;
+    mXmlReader = NULL;
+}
+
+int TestSerialPortBackend::speedByte()
+{
+    return 0x28; // standard speed (19200)
+}
+
+bool TestSerialPortBackend::setSpeed(int /*speed*/)
+{
+    return true;
+}
+
+QByteArray TestSerialPortBackend::readCommandFrame()
+{
+    if (!mXmlReader) return NULL;
+
+    QByteArray data;
+
+    data.resize(4);
+    do {
+    } while (mXmlReader->readNext() != QXmlStreamReader::StartElement);
+
+    if (mXmlReader->name() != "commandframe")
+        return NULL;
+
+    QXmlStreamAttributes attr = mXmlReader->attributes();
+    if (!attr.hasAttribute("device")
+        || !attr.hasAttribute("command")
+        || !attr.hasAttribute("aux1")
+        || !attr.hasAttribute("aux2"))
+        return NULL;
+
+    bool ok;
+    data[0] = attr.value("device").toInt(&ok, 16);
+    if (!ok)
+    {
+        data[0] = attr.value("device").toInt(&ok, 10);
+        if (!ok) return NULL;
+    }
+    data[1] = attr.value("command").toInt(&ok, 16);
+    if (!ok)
+    {
+        data[1] = attr.value("command").toInt(&ok, 10);
+        if (!ok) return NULL;
+    }
+    data[2] = attr.value("aux1").toInt(&ok, 16);
+    if (!ok)
+    {
+        data[2] = attr.value("aux1").toInt(&ok, 10);
+        if (!ok) return NULL;
+    }
+    data[3] = attr.value("aux2").toInt(&ok, 16);
+    if (!ok)
+    {
+        data[3] = attr.value("aux2").toInt(&ok, 10);
+        if (!ok) return NULL;
+    }
+
+    return data;
+}
+
+QByteArray TestSerialPortBackend::readDataFrame(uint size, bool verbose)
+{
+    if (!mXmlReader) return NULL;
+
+    do {
+    } while (mXmlReader->readNext() != QXmlStreamReader::StartElement);
+
+    if (mXmlReader->name() != "dataframe")
+        return NULL;
+
+    QByteArray data = mXmlReader->readElementText().toLatin1();
+    if (verbose)
+    {
+        qDebug() << "!n" << tr("Data frame contents: %1").arg(QString(data));
+        if (size != uint(data.size()))
+        {
+            qDebug() << "!n" << tr("Read: got %1 bytes, expected %2 bytes")
+                      .arg(data.size()).arg(size);
+        }
+    }
+
+    return data;
+}
+
+bool TestSerialPortBackend::writeDataFrame(const QByteArray &/*data*/)
+{
+    return true;
+}
+
+bool TestSerialPortBackend::writeCommandAck()
+{
+    return true;
+}
+
+bool TestSerialPortBackend::writeCommandNak()
+{
+    return true;
+}
+
+bool TestSerialPortBackend::writeDataAck()
+{
+    return true;
+}
+
+bool TestSerialPortBackend::writeDataNak()
+{
+    return true;
+}
+
+bool TestSerialPortBackend::writeComplete()
+{
+    return true;
+}
+
+bool TestSerialPortBackend::writeError()
+{
+    return true;
+}
+
+bool TestSerialPortBackend::writeRawFrame(const QByteArray &/*data*/)
+{
+    return true;
+}
+
+void TestSerialPortBackend::setActiveSioDevices(const QByteArray &/*data*/)
+{}

--- a/serialport-test.h
+++ b/serialport-test.h
@@ -40,6 +40,9 @@ public:
 protected:
     QString mTestFilename;
     QXmlStreamReader *mXmlReader;
+
+    bool readPauseTag();
+    void forwardXml();
 };
 
 #endif // SERIALPORTTEST_H

--- a/serialport-test.h
+++ b/serialport-test.h
@@ -1,9 +1,7 @@
 #ifndef SERIALPORTTEST_H
 #define SERIALPORTTEST_H
 
-#ifdef QT_NO_DEBUG
-#error "This class is not allowed in non-debug builds"
-#endif
+#ifndef QT_NO_DEBUG
 
 #include "serialport.h"
 
@@ -45,4 +43,5 @@ protected:
     void forwardXml();
 };
 
+#endif
 #endif // SERIALPORTTEST_H

--- a/serialport-test.h
+++ b/serialport-test.h
@@ -1,0 +1,45 @@
+#ifndef SERIALPORTTEST_H
+#define SERIALPORTTEST_H
+
+#ifdef QT_NO_DEBUG
+#error "This class is not allowed in non-debug builds"
+#endif
+
+#include "serialport.h"
+
+#include <QXmlStreamReader>
+
+class TestSerialPortBackend : public AbstractSerialPortBackend
+{
+    Q_OBJECT
+public:
+    TestSerialPortBackend(QObject *parent = 0);
+    virtual ~TestSerialPortBackend();
+
+    virtual bool open();
+    virtual bool isOpen();
+    virtual void close();
+    virtual void cancel();
+    virtual int speedByte();
+    virtual QByteArray readCommandFrame();
+    virtual QByteArray readDataFrame(uint size, bool verbose = true);
+    virtual bool writeDataFrame(const QByteArray &data);
+    virtual bool writeCommandAck();
+    virtual bool writeCommandNak();
+    virtual bool writeDataAck();
+    virtual bool writeDataNak();
+    virtual bool writeComplete();
+    virtual bool writeError();
+    virtual bool setSpeed(int speed);
+    virtual bool writeRawFrame(const QByteArray &data);
+    virtual void setActiveSioDevices(const QByteArray &data);
+
+    QString testFilename() { return mTestFilename; }
+    void setTestFilename(QString filename) { mTestFilename = filename; }
+
+protected:
+    QString mTestFilename;
+    QXmlStreamReader *mXmlReader;
+};
+
+#endif // SERIALPORTTEST_H

--- a/serialport.h
+++ b/serialport.h
@@ -26,7 +26,8 @@ enum eHandshake
 enum eSerialBackend
 {
     SERIAL_BACKEND_STANDARD=0,
-    SERIAL_BACKEND_SIO_DRIVER=1
+    SERIAL_BACKEND_SIO_DRIVER=1,
+    SERIAL_BACKEND_TEST = 99
 };
 
 enum eSIOConstants
@@ -95,6 +96,9 @@ signals:
 #ifdef Q_OS_UNIX
 #define SERIAL_PORT_LOCATION "/dev/"
 #include "serialport-unix.h"
+#endif
+#ifndef QT_NO_DEBUG
+#include "serialport-test.h"
 #endif
 
 #endif // SERIALPORT_H

--- a/sioworker.cpp
+++ b/sioworker.cpp
@@ -79,12 +79,20 @@ bool SioWorker::wait(unsigned long time)
 void SioWorker::start(Priority p)
 {
     switch (respeqtSettings->backend()) {
+#ifdef Q_NO_DEBUG
+        case SERIAL_BACKEND_TEST:
+#endif
         case SERIAL_BACKEND_STANDARD:
             mPort = new StandardSerialPortBackend(0);
             break;
         case SERIAL_BACKEND_SIO_DRIVER:
             mPort = new AtariSioBackend(0);
             break;
+#ifndef Q_NO_DEBUG
+        case SERIAL_BACKEND_TEST:
+            mPort = new TestSerialPortBackend(0);
+            break;
+#endif
     }
 
     QByteArray data;

--- a/sioworker.cpp
+++ b/sioworker.cpp
@@ -79,7 +79,7 @@ bool SioWorker::wait(unsigned long time)
 void SioWorker::start(Priority p)
 {
     switch (respeqtSettings->backend()) {
-#ifdef Q_NO_DEBUG
+#ifdef QT_NO_DEBUG
         case SERIAL_BACKEND_TEST:
 #endif
         case SERIAL_BACKEND_STANDARD:
@@ -88,7 +88,7 @@ void SioWorker::start(Priority p)
         case SERIAL_BACKEND_SIO_DRIVER:
             mPort = new AtariSioBackend(0);
             break;
-#ifndef Q_NO_DEBUG
+#ifndef QT_NO_DEBUG
         case SERIAL_BACKEND_TEST:
             mPort = new TestSerialPortBackend(0);
             break;


### PR DESCRIPTION
This implements an serial port backend for testing purposes.
It only is built, when compiler directive QT_NO_DEBUG is not set, i.e. as default only for debug build.
It uses an XML file for simulating SIO traffic.
Example of an test file:

```
<?xml` version="1.0" encoding="UTF-8"?>
<testcase>
    <pause sec="1" msec="1" />
    <!-- Get Status -->
    <commandframe device="0x40" command="0x53" aux1="0" aux2="0" />
    <pause sec="2" msec="10" />
    <!-- Write Chars -->
    <commandframe device="0x40" command="0x57" aux1="0x4e" aux2="0" />
    <pause sec="1" msec="10" />
    <!-- Data frame ending EOL, padded with spaces -->
    <dataframe>abcDEF&#155;                                 </dataframe>
    <pause sec="1" msec="1" />
</testcase>

```